### PR TITLE
[fixed?] Updated Archer logic so charging won't reset when an archer receives a resupply in online sandbox

### DIFF
--- a/Entities/Characters/Archer/ArcherLogic.as
+++ b/Entities/Characters/Archer/ArcherLogic.as
@@ -432,10 +432,10 @@ void ManageBow(CBlob@ this, ArcherInfo@ archer, RunnerMoveVars@ moveVars)
 		//	printf("charge_state " + charge_state );
 		if (hasarrow && charge_state == ArcherParams::no_arrows)
 		{
-			// (when key_action1 is down) reset charge state when:
-			// * the player has picks up arrows when inventory is empty
+			// (when key_action1 is down) set state to charging when:
+			// * the player has picked up arrows when inventory is empty
 			// * the player switches arrow type while charging bow
-			charge_state = ArcherParams::not_aiming;
+			charge_state = ArcherParams::charging;
 			just_action1 = true;
 		}
 


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of my knowledge) ready to be incorporated into the game.

## Description

Fixes #2075

When a player starts charging an arrow, regardless of how many arrows they have in their inventory, and they receive more arrows, their status should either be set to "charging" or remain "charging". This should hopefully resolve the issue of the Archer's charging state being reset when receiving a resupply in online Sandbox mode.

## Steps to Test or Reproduce

In the branch labeled Open-source-Contribution, start the game.

Enter an online Sandbox mode server.

Switch character to Archer, fire a few arrows, start charging your bow, then walk through the Archer workshop for a resupply.

See that the bow charging does not reset.
